### PR TITLE
HTML rendering & TCP port

### DIFF
--- a/labs/argo/README.md
+++ b/labs/argo/README.md
@@ -77,7 +77,7 @@ This installation of ArgoCD includes a web UI. The initial admin password is sto
 
 ```
 kubectl -n argocd get secret argocd-initial-admin-secret -o go-template="{{.data.password | base64decode}}"
-```
+```  <!-- -->
 
 Open the UI at http://localhost:30018, log in with username `admin` and the password from your Secret.
 


### PR DESCRIPTION
The code line 
kubectl -n argocd get secret argocd-initial-admin-secret -o go-template="{{.data.password | base64decode}}"
is not rendered correctly on the website.

There is no Service listening on port 30018 (Edit: my mistake there is)